### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/src/CoreIO.hs
+++ b/src/CoreIO.hs
@@ -143,7 +143,7 @@ getDoi :: String -> T.ErrMonad T.Ref
 getDoi doi = do
     let ps = [ "text/bibliography; style=bibtex" ]
         os = Wreq.defaults & Wreq.header "Accept" .~ ps
-        ad = "http://dx.doi.org/" ++ doi
+        ad = "https://doi.org/" ++ doi
     catchError ( tryToConnectWithGet os ad >>= readResponse ad )
                ( return . T.Missing doi "no-key"               )
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

I'd simply like to suggest to update the code that generates new DOI links accordingly.

Cheers!